### PR TITLE
Update Facade 

### DIFF
--- a/src/org/puremvc/haxe/multicore/patterns/facade/Facade.hx
+++ b/src/org/puremvc/haxe/multicore/patterns/facade/Facade.hx
@@ -63,7 +63,6 @@ class Facade implements IFacade
 	 */
 	public static function getInstance( key: String ): IFacade
 	{
-		if ( instanceMap == null ) instanceMap = new StringMap();
 		if ( !instanceMap.exists( key ) ) instanceMap.set(  key, new Facade( key ) );
 		return instanceMap.get( key );
 	}
@@ -284,6 +283,5 @@ class Facade implements IFacade
 	private var multitonKey: String;
 	
 	// The Multiton Facade instanceMap.
-	private static var instanceMap : StringMap<IFacade>;
-
+	private static var instanceMap : StringMap<IFacade> = new StringMap<IFacade>();
 }


### PR DESCRIPTION
Facade.instanceMap available by default otherwise constructor call fails! Will say, you can't extend the multiton facade right now. :)
